### PR TITLE
Damage immunity/resistance bypasses

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -621,12 +621,12 @@ export class sbiParser {
                 }
 
                 if (foundLine.toLowerCase().includes("adamantine")) {
-                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, "ada")
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, ["ada","mgc"])
                     await actor.update(actorData);
                 }
 
                 if (foundLine.toLowerCase().includes("silvered")) {
-                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, "sil")
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, ["sil","mgc"])
                     await actor.update(actorData);
                 }
             }

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -616,7 +616,17 @@ export class sbiParser {
                 }
 
                 if (foundLine.toLowerCase().includes("nonmagical weapons")) {
-                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.custom`, "From nonmagical weapons")
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, "mgc")
+                    await actor.update(actorData);
+                }
+
+                if (foundLine.toLowerCase().includes("adamantine")) {
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, "ada")
+                    await actor.update(actorData);
+                }
+
+                if (foundLine.toLowerCase().includes("silvered")) {
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, "sil")
                     await actor.update(actorData);
                 }
             }


### PR DESCRIPTION
Adds support for the Adamantine, Magical, and Silvered bypasses for Damage Resistance and Immunities.

The magical bypass wasnt getting picked up if the monster had adamantine or silver bypasses, so that's why those two include both magical and ada/sil, I dont believe there are any creatures that have ada/sil bypasses but not magical

Closes #60 