### PR TITLE
Minor Flee Mortals updates

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -621,6 +621,11 @@ export class sbiParser {
                     await actor.update(actorData);
                 }
 
+                if (foundLine.toLowerCase().includes("mundane attacks")) { ///Flee Mortals uses different terminology for this
+                    const actorData = sbiUtils.assignToObject({}, `data.traits.dr.bypasses`, "mgc")
+                    await actor.update(actorData);
+                }
+
                 if (foundLine.toLowerCase().includes("adamantine")) {
                     const actorData = sbiUtils.assignToObject({}, `data.traits.${typeValue}.bypasses`, ["ada","mgc"])
                     await actor.update(actorData);

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -33,7 +33,7 @@ export class sbiParser {
     static #damageTypesRegex = /\bbludgeoning\b|\bpiercing\b|\bslashing\b|\bacid\b|\bcold\b|\bfire\b|\blightning\b|\bnecrotic\b|\bpoison\b|\bpsychic\b|\bradiant\b|\bthunder\b/ig;
     static #conditionTypesRegex = /\bblinded\b|\bcharmed\b|\bdeafened\b|\bdiseased\b|\bexhaustion\b|\bfrightened\b|\bgrappled\b|\bincapacitated\b|\binvisible\b|\bparalyzed\b|\bpetrified\b|\bpoisoned\b|\bprone\b|\brestrained\b|\bstunned\b|\bunconscious\b/ig;
     static #sensesRegex = /(?<name>\bdarkvision\b|\bblindsight\b|\btremorsense\b|\btruesight\b) (?<modifier>\d+)/i;
-    static #challengeRegex = /^(challenge|cr|challenge rating)\s?(?<cr>(½|[\d\/]+))\s?(\((?<xp>[\d,]+)\s?xp\))?/i;
+    static #challengeRegex = /^(challenge|cr|challenge rating)\s?(?<cr>(½|[\d\/]+))(\s(?<role>\w+))?\s?(\((?<xp>[\d,]+)\s?xp\))?/i;
     static #spellCastingRegex = /\((?<slots>\d+) slot|(?<perday>\d+)\/day|spellcasting ability is (?<ability1>\w+)|(?<ability2>\w+) as the spellcasting ability|spell save dc (?<savedc>\d+)/ig;
     static #spellLevelRegex = /(?<level>\d+)(.+)level spellcaster/i;
     static #spellLineRegex = /(at-will|cantrips|1st|2nd|3rd|4th|5th|6th|7th|8th|9th)[\w\d\s\(\)-]*:/ig;
@@ -791,6 +791,10 @@ export class sbiParser {
 
             if (matchObj.match.groups.xp) {
                 sbiUtils.assignToObject(actorData, "data.details.xp.value", parseInt(matchObj.match.groups.xp.replace(",", "")));
+            }
+
+            if (matchObj.match.groups.role) {
+                sbiUtils.assignToObject(actorData, "data.details.source", matchObj.match.groups.role); //Places Flee Mortals Role into the creature's Source field
             }
 
             await actor.update(actorData);

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -67,7 +67,8 @@ export class sbiParser {
                 "mythic actions",
                 "lair actions",
                 "regional effects",
-                "villain actions"
+                "villain actions",
+                "utility spells"
             ];
 
             // Save off all the lines that precede the first of the above sections.

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -270,7 +270,7 @@ export class sbiParser {
             }
 
             sbiUtils.assignToObject(detailsData, "data.details.alignment", sbiUtils.capitalizeAll(matchObj.match.groups.alignment?.trim()));
-            sbiUtils.assignToObject(detailsData, "data.details.race", sbiUtils.capitalizeAll(matchObj.match.groups.race?.trim()));
+            sbiUtils.assignToObject(detailsData, "data.details.type.subtype", sbiUtils.capitalizeAll(matchObj.match.groups.race?.trim()));
             sbiUtils.assignToObject(detailsData, "data.details.type.value", matchObj.match.groups.type?.trim().toLowerCase());
 
             await actor.update(detailsData);

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -128,7 +128,7 @@ export class sbiParser {
             await this.setRacialDetailsAsync(storedLines, actor);
             await this.setArmorAsync(storedLines, actor);
             await this.setHealthAsync(storedLines, actor);
-            await this.setSoulsAsync(storedLins, actor);
+            await this.setSoulsAsync(storedLines, actor);
             await this.setSpeedAsync(storedLines, actor);
             await this.setInitiativeAsync(storedLines, actor);
             await this.setAbilitiesAsync(storedLines, actor);


### PR DESCRIPTION
This PR addresses several items in #58 
Utility Spells - added `sectionHeader` to create a feature for this section
Role - added capture group for Role and places it in the Source field of the creature (the user still needs to move the CR # Role text to the appropriate section of the statblock though)
Magical Resistance - FM uses "mundane attacks" so added a solution for that