### PR TITLE
FM - Villain Actions

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -14,14 +14,17 @@ class ActionDescription {
 
 export class sbiParser {
     // The action title regex is complicated. Here's the breakdown...
-    // ([A-Z][\w\d\-+,;']+[\s\-]?)               <- Represents the first word of the title, followed by a space or hyphen. It has to start with a capital letter.
-    //                                              The word can include word characters, digits, and some punctuation characters.
-    //                                              NOTE: Don't add more punctuation than is absolutely neccessary so that we don't get false positives.
-    // (of|and|the|from|in|at|on|with|to|by)\s)? <- Represents the prepostion words we want to ignore.
-    // ([\w\d\-+,;']+\s?){0,3}                   <- Represents the words that follow the first word, using the same regex for the allowed characters.
-    //                                              We assume the title only has 0-3 words following it, otherwise it's probably a sentence.
-    // (\([\w –\-\/]+\))?                        <- Represents an optional bit in parentheses, like '(Recharge 5-6)'.
-    static #actionTitleRegex = /^(([A-Z][\w\d\-+,;'’]+[\s\-]?)((of|and|the|from|in|at|on|with|to|by|into)\s)?([\w\d\-+,;']+\s?){0,3}(\((?!spell save)[^)]+\))?)[.!]/;
+    // (?!.*has three villain actions)              <- Rejects a match if the text contains "has three villain actions" - this is for Flee Mortals creatures
+    // (Action \d+: )?                              <- checks for an optional "Action #: " - this is for Flee Mortals creatures
+    // ([A-Z][\w\d\-+,;']+[\s\-]?)                  <- Represents the first word of the title, followed by a space or hyphen. It has to start with a capital letter.
+    //                                                 The word can include word characters, digits, and some punctuation characters.
+    //                                                 NOTE: Don't add more punctuation than is absolutely neccessary so that we don't get false positives.
+    // (of|and|the|from|in|at|on|with|to|by)\s)?    <- Represents the prepostion words we want to ignore.
+    // ([\w\d\-+,;'’]+\s?){0,5}                     <- Represents the words that follow the first word, using the same regex for the allowed characters.
+    //                                                 We assume the title only has 0-6 words following it, otherwise it's probably a sentence.
+    // (\((?!spell save)[^)]+\))?)                  <- Represents an optional bit in parentheses, like '(Recharge 5-6)'.
+    // [.!?]                                        <- Represents the characters at the end of the title's name
+    static #actionTitleRegex = /^((?!.*has three villain actions)(Action \d+: )?([A-Z][\w\d\-+,;']?[\s\-]?)((of|and|the|from|in|at|on|with|to|by|into)\s)?([\w\d\-+,;'’]+\s?){0,5}(\((?!spell save)[^)]+\))?)[.!?]/;
     static #racialDetailsRegex = /^(?<size>\bfine\b|\bdiminutive\b|\btiny\b|\bsmall\b|\bmedium\b|\blarge\b|\bhuge\b|\bgargantuan\b|\bcolossal\b)(\sswarm of (tiny|small))?\s(?<type>\w+)([,\s]+\((?<race>[,\w\s]+)\))?([,\s]+(?<alignment>[\w\s\-]+))?/i;
     static #armorRegex = /^((armor|armour) class)\s?(?<ac>\d+)( \((?<armortype>.+)\))?/i;
     static #hitPointsRegex = /^(hit points)\.?\s?(?<hp>\d+)\s?(\((?<formula>\d+d\d+( ?[\+\-−–] ?\d+)?)\))?/i;
@@ -910,6 +913,9 @@ export class sbiParser {
                         await actor.update(sbiUtils.assignToObject({}, "data.resources.legact.value", actionCount));
                         await actor.update(sbiUtils.assignToObject({}, "data.resources.legact.max", actionCount));
                     }
+                } else if (lowerActionName === "villain actions") {
+                    await actor.update(sbiUtils.assignToObject({}, "data.resources.legact.value", 3));
+                    await actor.update(sbiUtils.assignToObject({}, "data.resources.legact.max", 3));
                 }
 
                 const item = new Item(itemData);


### PR DESCRIPTION
Related to #58  
If Villain Actions are detected, sets the Legendary Action Uses fields to 3 

And some big tweaks to actionTitleRegex - it took me quite a while to get to something that was working for several of the different roadblocks I came up against, hopefully these changes don't impact other sources (only tested with FM 

`#actionTitleRegex = /^((?!.*has three villain actions)(Action \d+: )?([A-Z][\w\d\-+,;']?[\s\-]?)((of|and|the|from|in|at|on|with|to|by|into)\s)?([\w\d\-+,;'’]+\s?){0,5}(\((?!spell save)[^)]+\))?)[.!?]/;`

`(?!.*has three villain actions)` - rejects matches with the text "has three villain actions" this was necessary due to the increased word allotment below (it was creating a new feature with the title "X has three villain actions", which broke the Legendary Action Uses function)  
`(Action \d+: )?` - Optional match for villain actions, using this instead of adding `:` to the allowed punctuation saves one word allotment  
`([A-Z][\w\d\-+,;']?[\s\-]?)` - changed the `+` in between the `[ ]` groups to a `?` because a couple VAs start with "I " and they werent being captured. Not sure if this has wider implications for other issues.  
`[\w\d\-+,;'’]` - added `’` (weird apostrophe) that is used in a few VAs  
`{0,5}` - increase word allotment from 3 to 5 to account for all VAs (Queen Bargnot has the longest one) I think this could open the possibility of some unintended consequences for other statblocks?  
`[.!?]` - added `?` as a few VAs use it to end the title