### PR TITLE
Swarm and custom type support

### DIFF
--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -495,7 +495,12 @@ export class sbiActor {
         sUtils.assignToObject(detailsData, "data.details.alignment", sUtils.capitalizeAll(creatureData.alignment?.trim()));
         sUtils.assignToObject(detailsData, "data.details.race", sUtils.capitalizeAll(creatureData.race?.trim()));
         sUtils.assignToObject(detailsData, "data.details.type.value", creatureData.type?.trim());
+
+        const hasCustomType = creatureData.customType?.trim();
+        if(hasCustomType) {
+        sUtils.assignToObject(detailsData, "data.details.type.value", "custom");
         sUtils.assignToObject(detailsData, "data.details.type.custom", sUtils.capitalizeAll(creatureData.customType?.trim()));
+        }
 
         await actor.update(detailsData);
     }

--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -467,30 +467,35 @@ export class sbiActor {
     }
 
     static async setRacialDetailsAsync(actor, creatureData) {
+        const getSizeAbbreviation = (size) => {
+            switch (size) {
+                case "small":
+                    return "sm";
+                case "medium":
+                    return "med";
+                case "large":
+                    return "lg";
+                case "gargantuan":
+                    return "grg";
+                default:
+                    return size;
+            }
+        };
+        
         const sizeValue = creatureData.size.toLowerCase();
+        const swarmSizeValue = creatureData.swarmSize?.toLowerCase();
         const detailsData = {};
-
-        switch (sizeValue) {
-            case "small":
-                sUtils.assignToObject(detailsData, "data.traits.size", "sm");
-                break;
-            case "medium":
-                sUtils.assignToObject(detailsData, "data.traits.size", "med");
-                break;
-            case "large":
-                sUtils.assignToObject(detailsData, "data.traits.size", "lg");
-                break;
-            case "gargantuan":
-                sUtils.assignToObject(detailsData, "data.traits.size", "grg");
-                break;
-            default:
-                sUtils.assignToObject(detailsData, "data.traits.size", sizeValue);
-                break;
+        
+        sUtils.assignToObject(detailsData, "data.traits.size", getSizeAbbreviation(sizeValue));
+        
+        if (swarmSizeValue) {
+            sUtils.assignToObject(detailsData, "data.details.type.swarm", getSizeAbbreviation(swarmSizeValue));
         }
 
         sUtils.assignToObject(detailsData, "data.details.alignment", sUtils.capitalizeAll(creatureData.alignment?.trim()));
         sUtils.assignToObject(detailsData, "data.details.race", sUtils.capitalizeAll(creatureData.race?.trim()));
-        sUtils.assignToObject(detailsData, "data.details.type.value", creatureData.type?.trim().toLowerCase());
+        sUtils.assignToObject(detailsData, "data.details.type.value", creatureData.type?.trim());
+        sUtils.assignToObject(detailsData, "data.details.type.custom", sUtils.capitalizeAll(creatureData.customType?.trim()));
 
         await actor.update(detailsData);
     }

--- a/scripts/sbiData.js
+++ b/scripts/sbiData.js
@@ -80,6 +80,23 @@ export const KnownLanguages = [
     "undercommon"
 ];
 
+export const KnownCreatureTypes = [
+    "aberration",
+    "celestial",
+    "dragon",
+    "fey",
+    "giant",
+    "monstrosity",
+    "plant",
+    "beast",
+    "construct",
+    "elemental",
+    "fiend",
+    "humanoid",
+    "ooze",
+    "undead"
+];
+
 export class CreatureData {
     constructor(name) {
         this.name = name;                           // string

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -11,7 +11,8 @@ import {
     DamageConditionId,
     BlockID,
     TopBlocks,
-    KnownLanguages
+    KnownLanguages,
+    KnownCreatureTypes
 } from "./sbiData.js";
 
 // Steps that the parser goes through:
@@ -469,7 +470,16 @@ export class sbiParser {
         creature.size = match.groups.size;
         creature.alignment = match.groups.alignment?.trim();
         creature.race = match.groups.race?.trim();
-        creature.type = match.groups.type?.trim();
+        creature.swarmSize = match.groups.swarmsize?.trim();
+
+        const creatureType = match.groups.type?.toLowerCase().trim();
+        let singleCreatureType = creatureType.endsWith('s') ? creatureType.slice(0, -1) : creatureType;
+        if (singleCreatureType === "monstrositie") {
+            singleCreatureType = "monstrosity";
+        };
+        const isKnownType = KnownCreatureTypes.includes(singleCreatureType);
+        creature.type = isKnownType ? singleCreatureType : undefined;
+        creature.customType = isKnownType ? undefined : creatureType;
     }
 
     // Combines lines of text into sentences and paragraphs. This is complicated because finding 

--- a/scripts/sbiRegex.js
+++ b/scripts/sbiRegex.js
@@ -23,7 +23,7 @@ export class sbiRegex {
     static proficiencyBonus = /^proficiency bonus\s\+/i;
     // The racial details line is here instead of below because it doesn't have a 
     // standard starting word, so we have to look at the whole line.
-    static racialDetails = /^(?<size>\bfine\b|\bdiminutive\b|\btiny\b|\bsmall\b|\bmedium\b|\blarge\b|\bhuge\b|\bgargantuan\b|\bcolossal\b)(\sswarm of (tiny|small))?\s(?<type>\w+)([,\s]+\((?<race>[,\w\s]+)\))?([,\s]+(?<alignment>[\w\s\-]+))?/ig;
+    static racialDetails = /^(?<size>\bfine\b|\bdiminutive\b|\btiny\b|\bsmall\b|\bmedium\b|\blarge\b|\bhuge\b|\bgargantuan\b|\bcolossal\b)(\sswarm of (?<swarmsize>\w+))?\s(?<type>\w+)([,\s]+\((?<race>[,\w\s]+)\))?([,\s]+(?<alignment>[\w\s\-]+))?/ig;
     static reactions = /^reactions$/i;
     static savingThrows = /^(saving throws|saves)\s(\bstr\b|\bdex\b|\bcon\b|\bint\b|\bwis\b|\bcha\b)/i;
     static senses = /^senses.+\d+\s\bft\b/i;


### PR DESCRIPTION
Closes #76 and closes #77 

Ironically there is still an issue with Flee Mortals swarms, because of the way their statblock is formatted, the importer gets caught on the following line but I think that there are so few swarms in the book, and it seems like a niche case that this should be fine

![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/500d8e53-e4cf-44db-ac30-08d5a1f81c3c)

My first attempt as solving for this was to 'hard-code' the types into the racialDetails regex, but that made it insanely long, and wouldnt support custom types, so I think this is a better solution