### PR TITLE
FM Role adjustments and Subtype support

### DIFF
--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -320,7 +320,8 @@ export class sbiActor {
     static async setRoleAsync(actor, creatureData) {
         if (!creatureData.role) return;
 
-        await actor.update(sUtils.assignToObject({}, "data.details.type.subtype", creatureData.role));
+        await actor.update(sUtils.assignToObject({}, "data.details.source.custom", creatureData.role));
+        await actor.update(sUtils.assignToObject({}, "data.details.source.book", "Flee, Mortals!"));
     }
 
     static async setSavingThrowsAsync(actor, creatureData) {
@@ -489,7 +490,7 @@ export class sbiActor {
         }
 
         sUtils.assignToObject(detailsData, "data.details.alignment", sUtils.capitalizeAll(creatureData.alignment?.trim()));
-        sUtils.assignToObject(detailsData, "data.details.race", sUtils.capitalizeAll(creatureData.race?.trim()));
+        sUtils.assignToObject(detailsData, "data.details.type.subtype", sUtils.capitalizeAll(creatureData.race?.trim()));
         sUtils.assignToObject(detailsData, "data.details.type.value", creatureData.type?.trim().toLowerCase());
 
         await actor.update(detailsData);

--- a/scripts/sbiRegex.js
+++ b/scripts/sbiRegex.js
@@ -39,7 +39,7 @@ export class sbiRegex {
     static challengeDetails = /(?<cr>(½|[\d\/]+))\s?(\((?<xp>[\d,]+)\s?xp\))?/i;
     static rollDetails = /(?<value>\d+)\s?(\((?<formula>\d+d\d+(\s?[\+\-−–]\s?\d+)?)\))?/i;
     static perDayDetails = /(?<perday>\d+)\/day/i;
-    static roleDetails = /cr\s\d+(\s?\/?\s?\d+)?\s(?<role>\w+)/i;
+    static roleDetails = /\d+\s(?<role>\w+)/i;
     static savingThrowDetails = /must (make|succeed on) a dc (?<savedc>\d+) (?<saveability>\w+) (?<savetext>saving throw|save)/i;
     static sensesDetails = /(?<name>\bdarkvision\b|\bblindsight\b|\btremorsense\b|\btruesight\b) (?<modifier>\d+)/ig;
     static skillDetails = /(?<name>\bacrobatics\b|\barcana\b|\banimal handling\b|\bathletics\b|\bdeception\b|\bhistory\b|\binsight\b|\bintimidation\b|\binvestigation\b|\bmedicine\b|\bnature\b|\bperception\b|\bperformance\b|\bpersuasion\b|\breligion\b|\bsleight of hand\b|\bstealth\b|\bsurvival\b) (?<modifier>[\+|-]\d+)/ig;

--- a/scripts/sbiRegex.js
+++ b/scripts/sbiRegex.js
@@ -39,7 +39,7 @@ export class sbiRegex {
     static challengeDetails = /(?<cr>(½|[\d\/]+))\s?(\((?<xp>[\d,]+)\s?xp\))?/i;
     static rollDetails = /(?<value>\d+)\s?(\((?<formula>\d+d\d+(\s?[\+\-−–]\s?\d+)?)\))?/i;
     static perDayDetails = /(?<perday>\d+)\/day/i;
-    static roleDetails = /cr\s\d+\s(?<role>\w+)/i;
+    static roleDetails = /cr\s\d+(\s?\/?\s?\d+)?\s(?<role>\w+)/i;
     static savingThrowDetails = /must (make|succeed on) a dc (?<savedc>\d+) (?<saveability>\w+) (?<savetext>saving throw|save)/i;
     static sensesDetails = /(?<name>\bdarkvision\b|\bblindsight\b|\btremorsense\b|\btruesight\b) (?<modifier>\d+)/ig;
     static skillDetails = /(?<name>\bacrobatics\b|\barcana\b|\banimal handling\b|\bathletics\b|\bdeception\b|\bhistory\b|\binsight\b|\bintimidation\b|\binvestigation\b|\bmedicine\b|\bnature\b|\bperception\b|\bperformance\b|\bpersuasion\b|\breligion\b|\bsleight of hand\b|\bstealth\b|\bsurvival\b) (?<modifier>[\+|-]\d+)/ig;


### PR DESCRIPTION
Closes #82 and closes #81 
Moves the `<race>` capture group to the Subtype field
Moves the Role from the Subtype field to the Source Custom field
Adds "Flee, Mortals!" to the Source Book field if Role is present

Sample: Chimeron
Old | New
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/eb9fdf4e-acae-4be2-8f6e-55273e42b758)
