### PR TITLE
Per day fixes

### DIFF
--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -295,7 +295,7 @@ export class sbiActor {
             }
 
             this.setPerDay(name, itemData);
-            if (itemData.data?.uses.value) {
+            if (itemData.data.uses?.value) {
                 sUtils.assignToObject(itemData, "data.activation.type", "special");
             }
 

--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -177,6 +177,7 @@ export class sbiActor {
             sUtils.assignToObject(itemData, "flags.adnd5e.itemInfo.type", activationType);
             sUtils.assignToObject(itemData, "data.activation.type", activationType);
 
+            this.setPerDay(name, itemData);
             await this.setItemAsync(itemData, actor);
         }
     }
@@ -291,6 +292,11 @@ export class sbiActor {
                 sUtils.assignToObject(itemData, "data.consume.type", "attribute");
                 sUtils.assignToObject(itemData, "data.consume.target", "resources.legres.value");
                 sUtils.assignToObject(itemData, "data.consume.amount", 1);
+            }
+
+            this.setPerDay(name, itemData);
+            if (itemData.data?.uses.value) {
+                sUtils.assignToObject(itemData, "data.activation.type", "special");
             }
 
             await this.setItemAsync(itemData, actor);
@@ -825,7 +831,7 @@ export class sbiActor {
             const uses = match.groups.perday;
             sUtils.assignToObject(itemData, "data.uses.value", parseInt(uses));
             sUtils.assignToObject(itemData, "data.uses.max", uses);
-            sUtils.assignToObject(itemData, "data.range.per", "day");
+            sUtils.assignToObject(itemData, "data.uses.per", "day");
         }
     }
 


### PR DESCRIPTION
closes #93 
fixes `setPerDay` function 
Adds `setPerDay` to Minor Actions and Features, if a Feature has per day uses, also sets the Activation type to Special so that the details of the items looks correct and can be used

FM Human Storm Wizard
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/5683c80d-6f42-44f3-936a-4e2a67120f32)
