### PR TITLE
Set Spellcaster Level

### DIFF
--- a/scripts/sbiActor.js
+++ b/scripts/sbiActor.js
@@ -519,13 +519,6 @@ export class sbiActor {
 
         let spellObjs = [];
 
-        // Set spell level
-        const spellLevelMatch = sRegex.spellLevel.exec(description);
-
-        if (spellLevelMatch) {
-            sUtils.assignToObject(itemData, "data.details.spellLevel", parseInt(spellLevelMatch.groups.level));
-        }
-
         if (spells.length) {
             const descriptionLines = [];
             descriptionLines.push(`<p>${description}</p>`);
@@ -584,6 +577,13 @@ export class sbiActor {
                     });
                 }
             }
+        }
+
+        // Set spellcaster level
+        const spellcasterLevelMatch = sRegex.spellcasterLevel.exec(description);
+
+        if (spellcasterLevelMatch) {
+            await actor.update(sUtils.assignToObject({}, "data.details.spellLevel", parseInt(spellcasterLevelMatch.groups.level)));
         }
 
         // Set spellcasting ability.

--- a/scripts/sbiRegex.js
+++ b/scripts/sbiRegex.js
@@ -67,7 +67,7 @@ export class sbiRegex {
     static damageTypes = /\bbludgeoning\b|\bpiercing\b|\bslashing\b|\bacid\b|\bcold\b|\bfire\b|\blightning\b|\bnecrotic\b|\bpoison\b|\bpsychic\b|\bradiant\b|\bthunder\b/ig;
     static legendaryActionCount = /take (?<count>\d+) legendary/i;
     static nameValue = /(?<name>\w+)\s?(?<value>\d+)/ig;
-    static spellLevel = /(?<level>\d+)(.+)level spellcaster/i;
+    static spellcasterLevel = /(?<level>\d+)(.+)level spellcaster/i;
     static spellLine = /(at-will|cantrips|1st|2nd|3rd|4th|5th|6th|7th|8th|9th)[\w\d\s\(\)-]*:/ig;
     static spellInnateLine = /at will:|\d\/day( each)?:/ig;
     static spellInnateSingle = /innately cast (?<spellname>[\w|\s]+)(\s\(.+\))?,/i


### PR DESCRIPTION
Discovered in #86 
Clarify regex name, move spellcaster level to Actor data

Using UberNPC
Old:
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/0609498a-a1be-4ccf-a709-0508934a71ad)


New:
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/ae363994-ef73-45b0-898b-21b5231687ed)
