### PR TITLE
MotM spellcasting

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -208,7 +208,9 @@ export class sbiParser {
 
                 if (nameLower === "spellcasting") {
                     creature.innateSpellcasting = this.getSpells(actionData.value, sRegex.spellInnateLine);
-                } 
+                } else {
+                    creature[type] = this.getBlockDatas(lines);
+                }
             }
         }
         else {

--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -201,7 +201,17 @@ export class sbiParser {
             if (spellDatas.length === 1) {
                 creature.utilitySpells = this.getSpells(spellDatas[0].value, sRegex.spellInnateLine);
             }
-        } else {
+        } else if (type === BlockID.actions) {
+
+            for (const actionData of this.getBlockDatas(lines)) {
+                const nameLower = actionData.name.toLowerCase();
+
+                if (nameLower === "spellcasting") {
+                    creature.innateSpellcasting = this.getSpells(actionData.value, sRegex.spellInnateLine);
+                } 
+            }
+        }
+        else {
             creature[type] = this.getBlockDatas(lines);
         }
     }


### PR DESCRIPTION
Closes #97 
Marked as draft since there is still some work to be done to make it more correct, but this gets the spells imported at least.

Main drawback right now is that it doubles up on the Spellcasting information, creating both an Innate Spellcasting feature and the Spellcasting Action. Ideally the Innate Spellcasting item wouldnt be created, and stretch goal of the Spellcasting Action getting improved formatting.
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/1699ba69-f935-4213-990a-f74e5bb56c96)
![image](https://github.com/jbhaywood/5e-statblock-importer/assets/86370342/cce531ad-4ec9-4430-97d4-5fa7e5a07f7e)
