### PR TITLE
Parsing fixes

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -51,7 +51,8 @@ export class sbiParser {
                     continue;
                 }
 
-                const match = sRegex.getFirstMatch(line);
+                // Get the first block match, excluding the ones we already have
+                const match = sRegex.getFirstMatch(line, [...statBlocks.keys()]);
 
                 // This check is a little shaky, but it's the best we can do. We assume that if
                 // we've been going through the top blocks and hit a line that doesn't match anything
@@ -505,7 +506,7 @@ export class sbiParser {
 
             // Check to see if we've reached the end of the spell block by seeing if 
             // the next line is a title.
-            const nextLineIsTitle = index < validLines.length - 2
+            const nextLineIsTitle = index < validLines.length - 1
                 && sRegex.blockTitle.exec(validLines[index + 1]) != null;
 
             if (foundSpellBlock && nextLineIsTitle) {

--- a/scripts/sbiRegex.js
+++ b/scripts/sbiRegex.js
@@ -107,7 +107,7 @@ export class sbiRegex {
         { r: this.villainActions, id: BlockID.villainActions },
     ]
 
-    static getFirstMatch(line) {
-        return this.lineCheckRegexes.find(obj => obj.r.exec(line));
+    static getFirstMatch(line, excludeIds = []) {
+        return this.lineCheckRegexes.find(obj => obj.r.exec(line) && !excludeIds.includes(obj.id));
     }
 }


### PR DESCRIPTION
This should fix some open issues related to parsing.

- At the end of a spell block, the check to see if the next line is a title was skipping the last line;
- In the main parsing loop, when getting the first regex match, added exclusion of blocks already found.
